### PR TITLE
Update Revyzor test stub to vLLM v0.19.1

### DIFF
--- a/test/script/kvtest/Dockerfile
+++ b/test/script/kvtest/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.12.0
+FROM vllm/vllm-openai:v0.19.1
 
 # Dependencies for Revyzor connector
 RUN pip install --no-cache-dir \


### PR DESCRIPTION
## Summary

Updates the Revyzor test stub Dockerfile base image from `vllm/vllm-openai:v0.12.0` to `vllm/vllm-openai:v0.19.1`.

The KVConnectorBase_V1 interface is more mature in v0.19.1 — the connector has been validated against v0.19.1 on H100 hardware.

## Changes

- `test/script/kvtest/Dockerfile`: Base image `v0.12.0` → `v0.19.1`

No other changes. Test stub code is identical to the merged #166.