### PR TITLE
Add Revyzor production connector (placeholder)

### DIFF
--- a/test/script/kvtest/Dockerfile
+++ b/test/script/kvtest/Dockerfile
@@ -5,6 +5,10 @@ RUN pip install --no-cache-dir \
     cupy-cuda12x \
     nvidia-nvcomp-cu12
 
-# Install connector
-COPY revyzor_test_stub.py /app/revyzor_test_stub.py
+# Install production connector (compiled binary)
+# Replace the placeholder .so with the real binary from email before building
+COPY revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so /app/revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so
 ENV PYTHONPATH="/app:${PYTHONPATH}"
+
+# Keep test stub for reference
+COPY revyzor_test_stub.py /app/revyzor_test_stub.py

--- a/test/script/kvtest/revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so
+++ b/test/script/kvtest/revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so
@@ -1,0 +1,1 @@
+PLACEHOLDER — replace with revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so from email


### PR DESCRIPTION
## Summary

Adds the Revyzor production connector as a compiled binary (.so). The placeholder file in this PR should be replaced with the real binary sent via email before building the Docker image.

## Changes

- `test/script/kvtest/Dockerfile`: Updated to COPY the compiled `.so` instead of the test stub
- `test/script/kvtest/revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so`: Placeholder — replace with email attachment

## Usage

Replace the placeholder `.so` with the real binary, then build:

```bash
docker build -t inferx/revyzor:v0.2.0 test/script/kvtest/
```

vLLM launch flag:
```
--kv-transfer-config '{"kv_connector": "RevyzorConnector", "kv_connector_module_path": "revyzor_connector_inferx", "kv_role": "kv_both"}'
```

Optional environment variables:
- `REVYZOR_ROUNDTRIP=1` — enable full roundtrip compression
- `REVYZOR_LOSSLESS=1` — bit-exact lossless mode (1.45x)
- `REVYZOR_QUIET=1` — suppress per-layer logging