### PR TITLE
Update Revyzor connector to v1.1

### DIFF
--- a/test/script/kvtest/Dockerfile
+++ b/test/script/kvtest/Dockerfile
@@ -5,10 +5,7 @@ RUN pip install --no-cache-dir \
     cupy-cuda12x \
     nvidia-nvcomp-cu12
 
-# Install production connector (compiled binary)
-# Replace the placeholder .so with the real binary from email before building
+# Install production connector v1.1 (compiled binary, sent via email)
+# v1.1 changes: cleaner nvCOMP fallback logging, V3 cache reuse
 COPY revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so /app/revyzor_connector_inferx.cpython-312-x86_64-linux-gnu.so
 ENV PYTHONPATH="/app:${PYTHONPATH}"
-
-# Keep test stub for reference
-COPY revyzor_test_stub.py /app/revyzor_test_stub.py


### PR DESCRIPTION
## Summary
- Cleaner nvCOMP fallback logging — logs once per session instead of per-layer (removes log spam on CUDA driver mismatch)
- V3 cache reuse: skip compression roundtrip on prefix cache hits
- Removed unused test stub reference

## Important
**Please rebuild the Docker image from `test/script/kvtest/Dockerfile`.** The current `inferx/revyzor:v0.1.2` image was built before a dependency fix was merged — rebuilding will unlock full 3.2x compression instead of the 2x uint8 fallback.

Updated `.so` binary sent via email — drop it into `test/script/kvtest/` before building.

## Tested
- H100 80GB, vLLM 0.19.1, Qwen 7B, bfloat16
- Lossless mode: 1.5x, 104ms roundtrip
- Standard mode: 3.3x, 110ms roundtrip